### PR TITLE
ランキングを更新

### DIFF
--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -32,7 +32,7 @@ function App() {
       {/* 更新情報 */}
       <div className="bg-gray-50 rounded-lg p-4 text-sm mb-5">
         <div className="flex flex-wrap items-center gap-4 text-gray-600">
-          <span>📅最終更新: 2025年6月28日 16時00分</span>
+          <span>📅最終更新: 2025年7月6日 21時30分</span>
           <span>🔄更新頻度: 週1回</span>
           <span>
             <Link

--- a/src/workers/etyping-fetcher.ts
+++ b/src/workers/etyping-fetcher.ts
@@ -83,7 +83,7 @@ export function createEtypingFetcher({
         () => {
           return document.querySelector("ul.ranking li:not(.head)") !== null;
         },
-        { timeout: 3000 }
+        { timeout: 4000 }
       );
       console.log(`[EtypingFetcher] Page transition completed: ${page}`);
     } else {


### PR DESCRIPTION
ページ遷移で3000msの待機時間を超えてタイムアウトしていたため、4000msに延長